### PR TITLE
Fix case where pull request contains single quotes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,9 +42,11 @@ runs:
         echo "pull-request=${latest_pull_request}" >> ${GITHUB_OUTPUT}
     - name: Parse outputs
       id: parse-outputs
+      env:
+        PULL_REQUEST: ${{ steps.find-pr.outputs.pull-request }}
       shell: bash
       run: |
-        pull_request='${{ steps.find-pr.outputs.pull-request }}'
+        pull_request="${PULL_REQUEST}"
         id=$(echo "$pull_request" | jq -r '.id')
         number=$(echo "$pull_request" | jq -r '.number')
         url=$(echo "$pull_request" | jq -r '.url')


### PR DESCRIPTION
- The current action failed with a PR where the body contained a single '
character. This is because GitHub Actions expands expressions litterally
and we were previously using single quotes around the expansion.
